### PR TITLE
Enable more target frameworks

### DIFF
--- a/SeeShark.Example.Ascii/SeeShark.Example.Ascii.csproj
+++ b/SeeShark.Example.Ascii/SeeShark.Example.Ascii.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net5.0;</TargetFrameworks>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/SeeShark/SeeShark.csproj
+++ b/SeeShark/SeeShark.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Project">
     <AssemtlyTitle>SeeShark</AssemtlyTitle>
     <AssemblyName>SeeShark</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net5.0;</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ImplicitUsings>disable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This PR aims at providing more target frameworks for SeeShark.

So far, `net6.0` and `net5.0` have been tested and validated. `netstandard2.1` has been tested but failed to build because of some `Immutable` stuff not existing in `System.Collections`, along with some other things I don't exactly remember.

Just having `net5.0` and `net6.0` is already fine imo, but the more we can have without changing anything in the code the better, so if you have any suggestions I'll gladly take them.

- [x] `net6.0`
- [x] `net5.0`
- [ ] `netstandard2.1` (nope)