### PR TITLE
Use a `Disposable` abstract class

### DIFF
--- a/SeeShark/Camera.cs
+++ b/SeeShark/Camera.cs
@@ -8,14 +8,13 @@ using SeeShark.FFmpeg;
 
 namespace SeeShark
 {
-    public class Camera : IDisposable
+    public class Camera : Disposable
     {
         private Thread? decodingThread;
         private readonly CameraStreamDecoder decoder;
 
         public CameraInfo Info { get; }
         public bool IsPlaying { get; private set; }
-        public bool IsDisposed { get; private set; }
 
         public event EventHandler<FrameEventArgs>? OnFrame;
 
@@ -56,29 +55,14 @@ namespace SeeShark
             decodingThread.Start();
         }
 
-        public void Dispose()
+        protected override void DisposeManaged()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            StopCapture();
+            decoder.Dispose();
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected override void FreeUnmanaged()
         {
-            if (IsDisposed)
-                return;
-
-            if (disposing)
-            {
-                StopCapture();
-                decoder.Dispose();
-            }
-
-            IsDisposed = true;
-        }
-
-        ~Camera()
-        {
-            Dispose(false);
         }
     }
 }

--- a/SeeShark/Camera.cs
+++ b/SeeShark/Camera.cs
@@ -61,7 +61,7 @@ namespace SeeShark
             decoder.Dispose();
         }
 
-        protected override void FreeUnmanaged()
+        protected override void DisposeUnmanaged()
         {
         }
     }

--- a/SeeShark/CameraManager.cs
+++ b/SeeShark/CameraManager.cs
@@ -19,7 +19,7 @@ namespace SeeShark
     /// It can also watch for available devices, and fire up <see cref="OnNewDevice"/> and
     /// <see cref="OnLostDevice"/> events when it happens.
     /// </summary>
-    public sealed unsafe class CameraManager : IDisposable
+    public sealed unsafe class CameraManager : Disposable
     {
         private readonly AVInputFormat* avInputFormat;
         private readonly AVFormatContext* avFormatContext;
@@ -49,11 +49,6 @@ namespace SeeShark
         /// Invoked when a camera device has been disconnected.
         /// </summary>
         public event Action<CameraInfo>? OnLostDevice;
-
-        /// <summary>
-        /// Whether this <see cref="CameraManager"/> has been disposed yet.
-        /// </summary>
-        public bool IsDisposed { get; private set; }
 
         /// <summary>
         /// Enumerates available devices.
@@ -172,29 +167,14 @@ namespace SeeShark
             Devices = newDevices;
         }
 
-        public void Dispose()
+        protected override void DisposeManaged()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            deviceWatcher.Dispose();
         }
 
-        public void Dispose(bool disposing)
+        protected override void FreeUnmanaged()
         {
-            if (IsDisposed)
-                return;
-
-            if (disposing)
-            {
-                deviceWatcher.Dispose();
-            }
-
             ffmpeg.avformat_free_context(avFormatContext);
-            IsDisposed = true;
-        }
-
-        ~CameraManager()
-        {
-            Dispose(false);
         }
     }
 }

--- a/SeeShark/CameraManager.cs
+++ b/SeeShark/CameraManager.cs
@@ -172,7 +172,7 @@ namespace SeeShark
             deviceWatcher.Dispose();
         }
 
-        protected override void FreeUnmanaged()
+        protected override void DisposeUnmanaged()
         {
             ffmpeg.avformat_free_context(avFormatContext);
         }

--- a/SeeShark/Disposable.cs
+++ b/SeeShark/Disposable.cs
@@ -1,0 +1,45 @@
+// Copyright (c) The Vignette Authors
+// This file is part of SeeShark.
+// SeeShark is licensed under the BSD 3-Clause License. See LICENSE for details.
+
+using System;
+
+namespace SeeShark
+{
+    public abstract class Disposable : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public Disposable()
+        {
+            Disposed = false;
+        }
+
+        private void dispose(bool disposing)
+        {
+            if (Disposed)
+                return;
+
+            if (disposing)
+                DisposeManaged();
+
+            FreeUnmanaged();
+
+            Disposed = true;
+        }
+
+        public void Dispose()
+        {
+            dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected abstract void DisposeManaged();
+        protected abstract void FreeUnmanaged();
+
+        ~Disposable()
+        {
+            dispose(false);
+        }
+    }
+}

--- a/SeeShark/Disposable.cs
+++ b/SeeShark/Disposable.cs
@@ -23,7 +23,7 @@ namespace SeeShark
             if (disposing)
                 DisposeManaged();
 
-            FreeUnmanaged();
+            DisposeUnmanaged();
 
             Disposed = true;
         }
@@ -35,7 +35,7 @@ namespace SeeShark
         }
 
         protected abstract void DisposeManaged();
-        protected abstract void FreeUnmanaged();
+        protected abstract void DisposeUnmanaged();
 
         ~Disposable()
         {

--- a/SeeShark/FFmpeg/HardwareAccelStreamDecoder.cs
+++ b/SeeShark/FFmpeg/HardwareAccelStreamDecoder.cs
@@ -37,17 +37,11 @@ namespace SeeShark.FFmpeg
             return ret;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DisposeManaged()
         {
-            if (IsDisposed)
-                return;
+            base.DisposeManaged();
 
-            if (disposing)
-            {
-                HwFrame.Dispose();
-            }
-
-            base.Dispose(disposing);
+            HwFrame.Dispose();
         }
     }
 }

--- a/SeeShark/FFmpeg/VideoStreamDecoder.cs
+++ b/SeeShark/FFmpeg/VideoStreamDecoder.cs
@@ -15,7 +15,7 @@ namespace SeeShark.FFmpeg
     /// Decodes a video stream. <br/>
     /// Based on https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/master/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs.
     /// </summary>
-    public unsafe class VideoStreamDecoder : IDisposable
+    public unsafe class VideoStreamDecoder : Disposable
     {
         protected readonly AVCodecContext* CodecContext;
         protected readonly AVFormatContext* FormatContext;
@@ -27,8 +27,6 @@ namespace SeeShark.FFmpeg
         public readonly int FrameWidth;
         public readonly int FrameHeight;
         public readonly PixelFormat PixelFormat;
-
-        public bool IsDisposed { get; private set; }
 
         public VideoStreamDecoder(string url, AVInputFormat* inputFormat = null)
         {
@@ -121,23 +119,13 @@ namespace SeeShark.FFmpeg
             return result;
         }
 
-        public void Dispose()
+        protected override void DisposeManaged()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            Frame.Dispose();
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected override void FreeUnmanaged()
         {
-            if (IsDisposed)
-                return;
-
-            if (disposing)
-            {
-                // Dispose managed resources
-                Frame.Dispose();
-            }
-
             ffmpeg.avcodec_close(CodecContext);
 
             var formatContext = FormatContext;
@@ -145,13 +133,6 @@ namespace SeeShark.FFmpeg
 
             var packet = Packet;
             ffmpeg.av_packet_free(&packet);
-
-            IsDisposed = true;
-        }
-
-        ~VideoStreamDecoder()
-        {
-            Dispose(false);
         }
     }
 }

--- a/SeeShark/FFmpeg/VideoStreamDecoder.cs
+++ b/SeeShark/FFmpeg/VideoStreamDecoder.cs
@@ -124,7 +124,7 @@ namespace SeeShark.FFmpeg
             Frame.Dispose();
         }
 
-        protected override void FreeUnmanaged()
+        protected override void DisposeUnmanaged()
         {
             ffmpeg.avcodec_close(CodecContext);
 

--- a/SeeShark/Frame.cs
+++ b/SeeShark/Frame.cs
@@ -77,7 +77,7 @@ namespace SeeShark
         {
         }
 
-        protected override void FreeUnmanaged()
+        protected override void DisposeUnmanaged()
         {
             var frame = AVFrame;
             ffmpeg.av_frame_free(&frame);

--- a/SeeShark/Frame.cs
+++ b/SeeShark/Frame.cs
@@ -7,7 +7,7 @@ using FFmpeg.AutoGen;
 
 namespace SeeShark
 {
-    public sealed unsafe class Frame : IDisposable
+    public sealed unsafe class Frame : Disposable
     {
         internal readonly AVFrame* AVFrame;
 
@@ -33,8 +33,6 @@ namespace SeeShark
         /// Raw data of the frame in bytes.
         /// </summary>
         public ReadOnlySpan<byte> RawData => new ReadOnlySpan<byte>(AVFrame->data[0], WidthStep * Height);
-
-        public bool IsDisposed { get; private set; }
 
         // This constructor is internal because the user of the library
         // is not supposed to deal with any actual FFmpeg type.
@@ -75,30 +73,14 @@ namespace SeeShark
         /// </returns>
         internal int Receive(AVCodecContext* codecContext) => ffmpeg.avcodec_receive_frame(codecContext, AVFrame);
 
-        public void Dispose()
+        protected override void DisposeManaged()
         {
-            dispose(true);
-            GC.SuppressFinalize(this);
         }
 
-        private void dispose(bool disposing)
+        protected override void FreeUnmanaged()
         {
-            if (IsDisposed)
-                return;
-
-            if (disposing)
-            {
-            }
-
             var frame = AVFrame;
             ffmpeg.av_frame_free(&frame);
-
-            IsDisposed = true;
-        }
-
-        ~Frame()
-        {
-            dispose(false);
         }
     }
 }

--- a/SeeShark/FrameConverter.cs
+++ b/SeeShark/FrameConverter.cs
@@ -11,7 +11,7 @@ namespace SeeShark
     /// <summary>
     /// Converts a frame into another pixel format and/or resizes it.
     /// </summary>
-    public sealed unsafe class FrameConverter : IDisposable
+    public sealed unsafe class FrameConverter : Disposable
     {
         private readonly IntPtr convertedFrameBufferPtr;
         private readonly SwsContext* convertContext;
@@ -103,31 +103,15 @@ namespace SeeShark
             return DstFrame;
         }
 
-        public void Dispose()
+        protected override void DisposeManaged()
         {
-            dispose(true);
-            GC.SuppressFinalize(this);
+            DstFrame.Dispose();
         }
 
-        private void dispose(bool disposing)
+        protected override void FreeUnmanaged()
         {
-            if (IsDisposed)
-                return;
-
-            if (disposing)
-            {
-                DstFrame.Dispose();
-            }
-
             Marshal.FreeHGlobal(convertedFrameBufferPtr);
             ffmpeg.sws_freeContext(convertContext);
-
-            IsDisposed = true;
-        }
-
-        ~FrameConverter()
-        {
-            dispose(false);
         }
     }
 }

--- a/SeeShark/FrameConverter.cs
+++ b/SeeShark/FrameConverter.cs
@@ -108,7 +108,7 @@ namespace SeeShark
             DstFrame.Dispose();
         }
 
-        protected override void FreeUnmanaged()
+        protected override void DisposeUnmanaged()
         {
             Marshal.FreeHGlobal(convertedFrameBufferPtr);
             ffmpeg.sws_freeContext(convertContext);


### PR DESCRIPTION
In this PR, I made a `Disposable` abstract class to be used in place of `IDisposable` when the target class has nothing else to inherit.
It turned out to be much cleaner and way less repetitive, and the code has no class implementing `IDisposable` left since all the target classes had nothing to inherit.

I made it as a PR to get feedback on this idea. Do you think that making such a `Disposable` abstract class is still respecting the .NET standard, given that it is made so that the underlying code is what they recommend to write?

Regardless, I found no memory leak after this refactoring and everything works as expected.