### PR TITLE
Fix `CameraManager.GetCamera()` hanging and `FrameConverter` crashing

### DIFF
--- a/SeeShark.Example.Ascii/Program.cs
+++ b/SeeShark.Example.Ascii/Program.cs
@@ -121,6 +121,10 @@ namespace SeeShark.Example.Ascii
         /// </summary>
         public static void OnFrameEventHandler(object? _sender, FrameEventArgs e)
         {
+            // Don't redraw the frame if it's not new, unless it's resized.
+            if (e.Status != FFmpeg.DecodeStatus.NewFrame)
+                return;
+
             var frame = e.Frame;
             if (converter == null || Console.WindowWidth != converter.SrcWidth ||
                 Console.WindowHeight != converter.SrcHeight)
@@ -129,11 +133,6 @@ namespace SeeShark.Example.Ascii
                 // We have to dispose the previous one and instanciate a new one with the new window size.
                 converter?.Dispose();
                 converter = new FrameConverter(frame, Console.WindowWidth, Console.WindowHeight, PixelFormat.Gray8);
-            }
-            else if (e.Status != FFmpeg.DecodeStatus.NewFrame)
-            {
-                // Don't redraw the frame if it's not new, unless it's resized.
-                return;
             }
 
             // Resize the frame to the size of the terminal window, then draw it in ASCII.

--- a/SeeShark/FFmpeg/VideoStreamDecoder.cs
+++ b/SeeShark/FFmpeg/VideoStreamDecoder.cs
@@ -38,7 +38,6 @@ namespace SeeShark.FFmpeg
 
             var formatContext = FormatContext;
             ffmpeg.avformat_open_input(&formatContext, url, inputFormat, null).ThrowExceptionIfError();
-            ffmpeg.avformat_find_stream_info(formatContext, null).ThrowExceptionIfError();
 
             AVCodec* codec = null;
             StreamIndex = ffmpeg

--- a/SeeShark/FrameConverter.cs
+++ b/SeeShark/FrameConverter.cs
@@ -57,6 +57,9 @@ namespace SeeShark
             int srcWidth, int srcHeight, PixelFormat srcPixelFormat,
             int dstWidth, int dstHeight, PixelFormat dstPixelFormat)
         {
+            if (srcWidth == 0 || srcHeight == 0 || dstWidth == 0 || dstHeight == 0)
+                throw new ArgumentException("Source/Destination's Width/Height cannot be zero");
+
             SrcWidth = srcWidth;
             SrcHeight = srcHeight;
             DstWidth = dstWidth;


### PR DESCRIPTION
Maybe it would have been more organized to separate these in 2 different PRs, but the changes made are so small I just decided to do it that way.

This PR fixe #9.
It turns out that I don't even need to call `ffmpeg.avformat_find_stream_info()`. From the documentation:
> Read packets of a media file to get stream information. This is useful for file formats with no headers such as MPEG. This function also computes the real framerate in case of MPEG-2 repeat frame mode. The logical file position is not changed by this function; examined packets may be buffered for later processing.
It looks like it just works now. The camera gets retrieved but the `Width` and `Height` are at 0.
I wonder if I should make a warning, or have some way of detecting if the camera can get decoded.

This PR also fixes #10.
As for the `FrameConverter`, all I did was throwing an `ArgumentException` if any of the `Width`/`Height` properties are at 0.