### PR TITLE
Do not check for dependencies

### DIFF
--- a/SeeShark/FFmpeg/FFmpegManager.cs
+++ b/SeeShark/FFmpeg/FFmpegManager.cs
@@ -118,10 +118,11 @@ namespace SeeShark.FFmpeg
             return libraries.ToStrings().All((lib) => canLoadLibrary(lib, path, validated));
         }
 
-        // Note: dependencies are not checked as they are optional in FFmpeg.AutoGen.
-        // See following links:
-        // - https://github.com/Ruslan-B/FFmpeg.AutoGen/commit/395dea80c642c85e089e3d7721f91d77594655c1
-        // - https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/633c15d323785092561329ad4b5742b0189116d6/FFmpeg.AutoGen/FFmpeg.cs#L57-L82
+        /// <remarks>
+        /// Note: dependencies are not checked as they are optional in FFmpeg.AutoGen.
+        /// See <see href="https://github.com/Ruslan-B/FFmpeg.AutoGen/commit/395dea80c642c85e089e3d7721f91d77594655c1">the following commit</see>
+        /// and <see href="https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/633c15d323785092561329ad4b5742b0189116d6/FFmpeg.AutoGen/FFmpeg.cs#L57-L82">this function</see>
+        /// </remarks>
         private static bool canLoadLibrary(string lib, string path, List<string> validated)
         {
             if (validated.Contains(lib))

--- a/SeeShark/FFmpeg/FFmpegManager.cs
+++ b/SeeShark/FFmpeg/FFmpegManager.cs
@@ -118,7 +118,10 @@ namespace SeeShark.FFmpeg
             return libraries.ToStrings().All((lib) => canLoadLibrary(lib, path, validated));
         }
 
-        // Note: recurses in a very similar way to the LoadLibrary() method.
+        // Note: dependencies are not checked as they are optional in FFmpeg.AutoGen.
+        // See following links:
+        // - https://github.com/Ruslan-B/FFmpeg.AutoGen/commit/395dea80c642c85e089e3d7721f91d77594655c1
+        // - https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/633c15d323785092561329ad4b5742b0189116d6/FFmpeg.AutoGen/FFmpeg.cs#L57-L82
         private static bool canLoadLibrary(string lib, string path, List<string> validated)
         {
             if (validated.Contains(lib))
@@ -129,9 +132,7 @@ namespace SeeShark.FFmpeg
                 return false;
 
             validated.Add(lib);
-
-            var dependencies = ffmpeg.LibraryDependenciesMap[lib];
-            return dependencies.Except(validated).All((dep) => canLoadLibrary(dep, path, validated));
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #15.

I hadn't read the code of `LoadLibrary` properly and assumed that dependencies were required as they were used during the loading process.
I was wrong, they are only being loaded with `n => LoadLibrary(libraryName: n, throwException: false)`, which means that if it fails to load it won't throw an exception.
https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/633c15d323785092561329ad4b5742b0189116d6/FFmpeg.AutoGen/FFmpeg.cs#L57-L82

Thus, it means that to be able to load a library you don't need to be able to load its dependencies.
Pretty simple fix in the end.