### PR TITLE
Move wait-longer logic to `VideoDevice`

### DIFF
--- a/SeeShark/Decode/VideoStreamDecoder.cs
+++ b/SeeShark/Decode/VideoStreamDecoder.cs
@@ -30,6 +30,7 @@ namespace SeeShark.Decode
         public readonly int FrameWidth;
         public readonly int FrameHeight;
         public readonly PixelFormat PixelFormat;
+        public AVRational Framerate => Stream->r_frame_rate;
 
         public VideoStreamDecoder(string url, DeviceInputFormat inputFormat, IDictionary<string, string>? options = null)
             : this(url, ffmpeg.av_find_input_format(inputFormat.ToString()), options)


### PR DESCRIPTION
Currently, the `VideoStreamDecoder` waits longer before decoding a frame. It does make sense for a camera or display stream as they have to be decoded live in synchronization with the framerate. However, it makes less sense for an eventual video stream. Were we planning to support such a thing in the future, making this move is necessary.