### PR TITLE
Add null checks to `DisposeUnmanaged()` methods

### DIFF
--- a/SeeShark.Example.Ascii/SeeShark.Example.Ascii.csproj
+++ b/SeeShark.Example.Ascii/SeeShark.Example.Ascii.csproj
@@ -8,10 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FFmpeg.AutoGen" Version="5.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\SeeShark\SeeShark.csproj" />
     </ItemGroup>
 

--- a/SeeShark/Decode/HardwareAccelStreamDecoder.cs
+++ b/SeeShark/Decode/HardwareAccelStreamDecoder.cs
@@ -19,18 +19,18 @@ namespace SeeShark.Decode
             HardwareAccelDevice hwAccelDevice, AVInputFormat* inputFormat = null)
         : base(url, inputFormat)
         {
+            HwFrame = new Frame();
+
             ffmpeg.av_hwdevice_ctx_create(
                 &CodecContext->hw_device_ctx,
                 (AVHWDeviceType)hwAccelDevice,
                 null, null, 0
             ).ThrowExceptionIfError();
-
-            HwFrame = new Frame();
         }
 
         public new DecodeStatus TryDecodeNextFrame(out Frame nextFrame)
         {
-            var ret = base.TryDecodeNextFrame(out var frame);
+            DecodeStatus ret = base.TryDecodeNextFrame(out var frame);
 
             frame.HardwareAccelCopyTo(HwFrame).ThrowExceptionIfError();
             nextFrame = HwFrame;

--- a/SeeShark/Decode/VideoStreamDecoder.cs
+++ b/SeeShark/Decode/VideoStreamDecoder.cs
@@ -161,7 +161,7 @@ namespace SeeShark.Decode
             // so we need to null check everything.
             // See https://github.com/vignetteapp/SeeShark/issues/27
 
-            if (CodecContext != null)
+            if (CodecContext != null && ffmpeg.avcodec_is_open(CodecContext) > 0)
                 ffmpeg.avcodec_close(CodecContext);
 
             if (FormatContext != null)

--- a/SeeShark/Decode/VideoStreamDecoder.cs
+++ b/SeeShark/Decode/VideoStreamDecoder.cs
@@ -31,6 +31,8 @@ namespace SeeShark.Decode
         public readonly int FrameHeight;
         public readonly PixelFormat PixelFormat;
 
+        private bool isFormatContextOpen = false;
+
         public VideoStreamDecoder(string url, DeviceInputFormat inputFormat, IDictionary<string, string>? options = null)
             : this(url, ffmpeg.av_find_input_format(inputFormat.ToString()), options)
         {
@@ -118,6 +120,7 @@ namespace SeeShark.Decode
                     throw new InvalidOperationException("Packet does not belong to the decoder's video stream");
 
                 ffmpeg.avcodec_send_packet(CodecContext, Packet).ThrowExceptionIfError();
+                isFormatContextOpen = true;
 
                 Frame.Unref();
                 error = Frame.Receive(CodecContext);
@@ -164,7 +167,7 @@ namespace SeeShark.Decode
             if (CodecContext != null && ffmpeg.avcodec_is_open(CodecContext) > 0)
                 ffmpeg.avcodec_close(CodecContext);
 
-            if (FormatContext != null)
+            if (FormatContext != null && isFormatContextOpen)
             {
                 AVFormatContext* formatContext = FormatContext;
                 ffmpeg.avformat_close_input(&formatContext);

--- a/SeeShark/Decode/VideoStreamDecoder.cs
+++ b/SeeShark/Decode/VideoStreamDecoder.cs
@@ -157,13 +157,24 @@ namespace SeeShark.Decode
 
         protected override void DisposeUnmanaged()
         {
-            ffmpeg.avcodec_close(CodecContext);
+            // Constructor initialization can fail at some points,
+            // so we need to null check everything.
+            // See https://github.com/vignetteapp/SeeShark/issues/27
 
-            var formatContext = FormatContext;
-            ffmpeg.avformat_close_input(&formatContext);
+            if (CodecContext != null)
+                ffmpeg.avcodec_close(CodecContext);
 
-            var packet = Packet;
-            ffmpeg.av_packet_free(&packet);
+            if (FormatContext != null)
+            {
+                AVFormatContext* formatContext = FormatContext;
+                ffmpeg.avformat_close_input(&formatContext);
+            }
+
+            if (Packet != null)
+            {
+                AVPacket* packet = Packet;
+                ffmpeg.av_packet_free(&packet);
+            }
         }
     }
 }

--- a/SeeShark/Decode/VideoStreamDecoder.cs
+++ b/SeeShark/Decode/VideoStreamDecoder.cs
@@ -54,8 +54,10 @@ namespace SeeShark.Decode
                     ffmpeg.av_dict_set(&dict, pair.Key, pair.Value, 0);
             }
 
-            ffmpeg.avformat_open_input(&formatContext, url, inputFormat, &dict).ThrowExceptionIfError();
+            int openInputErr = ffmpeg.avformat_open_input(&formatContext, url, inputFormat, &dict);
             ffmpeg.av_dict_free(&dict);
+            openInputErr.ThrowExceptionIfError();
+            isFormatContextOpen = true;
 
             AVCodec* codec = null;
             StreamIndex = ffmpeg
@@ -120,7 +122,6 @@ namespace SeeShark.Decode
                     throw new InvalidOperationException("Packet does not belong to the decoder's video stream");
 
                 ffmpeg.avcodec_send_packet(CodecContext, Packet).ThrowExceptionIfError();
-                isFormatContextOpen = true;
 
                 Frame.Unref();
                 error = Frame.Receive(CodecContext);

--- a/SeeShark/Frame.cs
+++ b/SeeShark/Frame.cs
@@ -79,8 +79,11 @@ namespace SeeShark
 
         protected override void DisposeUnmanaged()
         {
-            var frame = AVFrame;
-            ffmpeg.av_frame_free(&frame);
+            if (AVFrame != null)
+            {
+                AVFrame* frame = AVFrame;
+                ffmpeg.av_frame_free(&frame);
+            }
         }
     }
 }

--- a/SeeShark/FrameConverter.cs
+++ b/SeeShark/FrameConverter.cs
@@ -112,8 +112,15 @@ namespace SeeShark
 
         protected override void DisposeUnmanaged()
         {
-            Marshal.FreeHGlobal(convertedFrameBufferPtr);
-            ffmpeg.sws_freeContext(convertContext);
+            // Constructor initialization can fail at some points,
+            // so we need to null check everything.
+            // See https://github.com/vignetteapp/SeeShark/issues/27
+
+            if (convertedFrameBufferPtr != null)
+                Marshal.FreeHGlobal(convertedFrameBufferPtr);
+
+            if (convertContext != null)
+                ffmpeg.sws_freeContext(convertContext);
         }
     }
 }


### PR DESCRIPTION
Fixes #27.

I added null checks to all unsafe objects of SeeShark (which isn't a lot).

@lubagov This shouldn't fix the I/O error you're getting, but at least the Access Violation shouldn't be there anymore.
Can you test to see if it works?