### PR TITLE
Circumvent camera buffering and let the user handle `EndOfStream`

### DIFF
--- a/SeeShark/Device/VideoDevice.cs
+++ b/SeeShark/Device/VideoDevice.cs
@@ -17,6 +17,7 @@ namespace SeeShark.Device
         public bool IsPlaying { get; private set; }
 
         public event EventHandler<FrameEventArgs>? OnFrame;
+        public event EventHandler<DecodeStatus>? OnEndOfStream;
 
         public VideoDevice(VideoDeviceInfo info, DeviceInputFormat inputFormat, VideoInputOptions? options = null)
         {
@@ -34,6 +35,10 @@ namespace SeeShark.Device
                 if (!IsPlaying)
                     break;
             }
+
+            // End of stream happened
+            OnEndOfStream?.Invoke(this, status);
+            IsPlaying = false;
         }
 
         /// <summary>

--- a/SeeShark/FrameConverter.cs
+++ b/SeeShark/FrameConverter.cs
@@ -116,7 +116,7 @@ namespace SeeShark
             // so we need to null check everything.
             // See https://github.com/vignetteapp/SeeShark/issues/27
 
-            if (convertedFrameBufferPtr != null)
+            if (convertedFrameBufferPtr != IntPtr.Zero)
                 Marshal.FreeHGlobal(convertedFrameBufferPtr);
 
             if (convertContext != null)


### PR DESCRIPTION
Fixes #29 ... While waiting for SeeShark to have a good multithreaded system for the user to process received frames.

The method of waiting has been changed to accommodate for camera buffering and variable FPS.
Finally, an event handler for when the `VideoStreamDecoder`'s decode loop hits EndOfStream has been added (previously, the user would just stop receiving frames without knowing why).

I'll note that there's probably something more useful than the `DecodeStatus` that we can send, as it will always be equal to `DecodeStatus.EndOfStream`...