### PR TITLE
include composite display in enumeration

### DIFF
--- a/SeeShark/Device/DisplayInfo.cs
+++ b/SeeShark/Device/DisplayInfo.cs
@@ -11,5 +11,7 @@ namespace SeeShark.Device
         public int Width { get; init; }
         public int Height { get; init; }
         public bool Primary { get; init; }
+
+        public bool IsComposite { get; init; }
     }
 }

--- a/SeeShark/Device/DisplayManager.cs
+++ b/SeeShark/Device/DisplayManager.cs
@@ -44,9 +44,9 @@ namespace SeeShark.Device
 
                     DisplayInfo[] info = new DisplayInfo[monitors.Length + 1];
 
-                    int compositeLeft = Int32.MaxValue;
+                    int compositeLeft = int.MaxValue;
                     int compositeRight = 0;
-                    int compositeTop = Int32.MaxValue;
+                    int compositeTop = int.MaxValue;
                     int compositeBottom = 0;
 
                     for (int i = 0; i < monitors.Length; i++)
@@ -66,14 +66,14 @@ namespace SeeShark.Device
                         if (monitor.X < compositeLeft)
                             compositeLeft = monitor.X;
 
-                        if ((monitor.X + monitor.Width) > compositeRight)
-                            compositeRight = (monitor.X + monitor.Width);
+                        if (monitor.X + monitor.Width > compositeRight)
+                            compositeRight = monitor.X + monitor.Width;
 
                         if (monitor.Y < compositeTop)
                             compositeTop = monitor.Y;
 
-                        if ((monitor.Y + monitor.Height) > compositeBottom)
-                            compositeBottom = (monitor.Y + monitor.Height);
+                        if (monitor.Y + monitor.Height > compositeBottom)
+                            compositeBottom = monitor.Y + monitor.Height;
                     }
 
                     info[0] = new DisplayInfo

--- a/SeeShark/Device/DisplayManager.cs
+++ b/SeeShark/Device/DisplayManager.cs
@@ -49,13 +49,12 @@ namespace SeeShark.Device
                     int compositeTop = Int32.MaxValue;
                     int compositeBottom = 0;
 
-                    for (int i = 0; i < info.Length - 1; i++)
+                    for (int i = 0; i < monitors.Length; i++)
                     {
                         XRRMonitorInfo monitor = monitors[i];
-                        string nameAddition = monitor.Name == null ? "" : $" ({new string(monitor.Name)})";
                         info[i + 1] = new DisplayInfo
                         {
-                            Name = $"Display {i}{nameAddition}",
+                            Name = $"Display {i}",
                             Path = ":0",
                             X = monitor.X,
                             Y = monitor.Y,

--- a/SeeShark/Device/DisplayManager.cs
+++ b/SeeShark/Device/DisplayManager.cs
@@ -42,12 +42,18 @@ namespace SeeShark.Device
                     IntPtr rootWindow = XLib.XDefaultRootWindow(display);
                     XRRMonitorInfo[] monitors = getXRandrDisplays(display, rootWindow);
 
-                    DisplayInfo[] info = new DisplayInfo[monitors.Length];
-                    for (int i = 0; i < info.Length; i++)
+                    DisplayInfo[] info = new DisplayInfo[monitors.Length + 1];
+
+                    int compositeLeft = Int32.MaxValue;
+                    int compositeRight = 0;
+                    int compositeTop = Int32.MaxValue;
+                    int compositeBottom = 0;
+
+                    for (int i = 0; i < info.Length - 1; i++)
                     {
                         XRRMonitorInfo monitor = monitors[i];
                         string nameAddition = monitor.Name == null ? "" : $" ({new string(monitor.Name)})";
-                        info[i] = new DisplayInfo
+                        info[i + 1] = new DisplayInfo
                         {
                             Name = $"Display {i}{nameAddition}",
                             Path = ":0",
@@ -57,8 +63,31 @@ namespace SeeShark.Device
                             Height = monitor.Height,
                             Primary = monitor.Primary > 0,
                         };
+
+                        if (monitor.X < compositeLeft)
+                            compositeLeft = monitor.X;
+
+                        if ((monitor.X + monitor.Width) > compositeRight)
+                            compositeRight = (monitor.X + monitor.Width);
+
+                        if (monitor.Y < compositeTop)
+                            compositeTop = monitor.Y;
+
+                        if ((monitor.Y + monitor.Height) > compositeBottom)
+                            compositeBottom = (monitor.Y + monitor.Height);
                     }
 
+                    info[0] = new DisplayInfo
+                    {
+                        Name = $"Composite X11 Display",
+                        Path = ":0",
+                        X = compositeLeft,
+                        Y = compositeTop,
+                        Width = compositeRight - compositeLeft,
+                        Height = compositeBottom - compositeTop,
+                        Primary = false,
+                        IsComposite = true
+                    };
                     return info;
                 }
             }

--- a/SeeShark/Interop/X11/XRRMonitorInfo.cs
+++ b/SeeShark/Interop/X11/XRRMonitorInfo.cs
@@ -10,7 +10,7 @@ namespace SeeShark.Interop.X11
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct XRRMonitorInfo
     {
-        public sbyte* Name;
+        public ulong Name;
         public int Primary;
         public int Automatic;
         public int NOutput;


### PR DESCRIPTION
Adds support for enumerating the composite display (the whole screen surface)
![image](https://user-images.githubusercontent.com/46694241/198622373-066cc7fe-a68d-4cb7-8c77-9ec9c6244f7f.png)
