### PR TITLE
Add display capture input options

### DIFF
--- a/SeeShark/Device/DisplayManager.cs
+++ b/SeeShark/Device/DisplayManager.cs
@@ -28,8 +28,26 @@ namespace SeeShark.Device
         {
         }
 
-        public override Display GetDevice(DisplayInfo info, VideoInputOptions? options = null) =>
-            new Display(info, InputFormat, options);
+        public override Display GetDevice(DisplayInfo info, VideoInputOptions? options = null)
+        {
+            if (options is { } o)
+            {
+                return new Display(info, InputFormat, o);
+            }
+            else
+            {
+                return new Display(info, InputFormat, generateInputOptions(info));
+            }
+        }
+
+        private VideoInputOptions generateInputOptions(DisplayInfo info)
+        {
+            return new VideoInputOptions
+            {
+                VideoSize = (info.Width, info.Height),
+                VideoPosition = (info.X, info.Y)
+            };
+        }
 
         /// <summary>
         /// Enumerates available devices.

--- a/SeeShark/Device/VideoDevice.cs
+++ b/SeeShark/Device/VideoDevice.cs
@@ -22,7 +22,7 @@ namespace SeeShark.Device
         public VideoDevice(VideoDeviceInfo info, DeviceInputFormat inputFormat, VideoInputOptions? options = null)
         {
             Info = info;
-            decoder = new VideoStreamDecoder(info.Path, inputFormat, options?.ToAVDictOptions());
+            decoder = new VideoStreamDecoder(info.Path, inputFormat, options?.ToAVDictOptions(inputFormat));
         }
 
         protected void DecodeLoop()

--- a/SeeShark/VideoInputOptions.cs
+++ b/SeeShark/VideoInputOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using FFmpeg.AutoGen;
+using SeeShark.Device;
 
 namespace SeeShark
 {
@@ -27,6 +28,12 @@ namespace SeeShark
         /// </remarks>
         /// <value>(width, height)</value>
         public (int, int)? VideoSize { get; set; }
+
+        /// <summary>
+        /// To request the capture to start from a specific point
+        /// </summary>
+        /// <value>(x, y)</value>
+        public (int, int)? VideoPosition { get; set; }
         /// <summary>
         /// To request a specific framerate for the video stream.
         /// </summary>
@@ -42,7 +49,7 @@ namespace SeeShark
         /// <summary>
         /// Combines all properties into a dictionary of options that FFmpeg can use.
         /// </summary>
-        public virtual IDictionary<string, string> ToAVDictOptions()
+        public virtual IDictionary<string, string> ToAVDictOptions(DeviceInputFormat? inputFormat = null)
         {
             Dictionary<string, string> dict = new();
 
@@ -56,6 +63,24 @@ namespace SeeShark
             if (InputFormat != null)
                 dict.Add("input_format", InputFormat);
 
+            if (VideoPosition != null)
+            {
+                switch (inputFormat)
+                {
+                    case DeviceInputFormat.X11Grab:
+                        {
+                            dict.Add("grab_x", VideoPosition.Value.Item1.ToString());
+                            dict.Add("grab_y", VideoPosition.Value.Item2.ToString());
+                            break;
+                        }
+                    case DeviceInputFormat.GdiGrab:
+                        {
+                            dict.Add("offset_x", VideoPosition.Value.Item1.ToString());
+                            dict.Add("offset_y", VideoPosition.Value.Item2.ToString());
+                            break;
+                        }
+                }
+            }
             return dict;
         }
     }


### PR DESCRIPTION
Depends on #36 

This PR makes it possible to actually use the specified display information when capturing both on `x11grab` and `gdigrab`.

The autogenerated input options are used ***only*** if the user didn't specify custom ones already.

Tested on both my linux system and a windows VM.