### PR TITLE
Include missing using in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ using System;
 using System.Threading;
 using SeeShark;
 using SeeShark.FFmpeg;
+using SeeShark.Device;
 
 namespace YourProgram;
 


### PR DESCRIPTION
While working with the library, and using the example code in the README. I noticed that the ```CameraManager``` could not be found. 

The README.md should include the device namespace.